### PR TITLE
Fix division by zero

### DIFF
--- a/report.go
+++ b/report.go
@@ -38,8 +38,8 @@ func (t *TextReport) Print(res *Result) {
 	fmt.Printf("Imports:       %v\n", res.Import)
 	fmt.Printf("Structs:       %v\n", res.Struct)
 	fmt.Printf("Interfaces:    %v\n", res.Interface)
-	fmt.Printf("Methods:       %v (%v Exported, %v LOC, %v LOC Avg.)\n", res.Method, res.ExportedMethod, res.MethodLOC, res.MethodLOC/res.Method)
-	fmt.Printf("Functions:     %v (%v Exported, %v LOC, %v LOC Avg.)\n", res.Function, res.ExportedFunction, res.FunctionLOC, res.FunctionLOC/res.Function)
+	fmt.Printf("Methods:       %v (%v Exported, %v LOC, %v LOC Avg.)\n", res.Method, res.ExportedMethod, res.MethodLOC, checkZeroDivide(res.MethodLOC, res.Method))
+	fmt.Printf("Functions:     %v (%v Exported, %v LOC, %v LOC Avg.)\n", res.Function, res.ExportedFunction, res.FunctionLOC, checkZeroDivide(res.FunctionLOC, res.Function))
 	fmt.Println(strings.Repeat("-", 80))
 	fmt.Printf("Ifs:           %v \n", res.IfStatement)
 	fmt.Printf("Switches:      %v \n", res.IfStatement)
@@ -49,4 +49,12 @@ func (t *TextReport) Print(res *Result) {
 	fmt.Printf("Assertions:    %v \n", res.Assertion)
 	fmt.Println(strings.Repeat("-", 80))
 	fmt.Printf("\n")
+}
+
+func checkZeroDivide(num, den int) int {
+	if den == 0 {
+		return 0
+	} else {
+		return num / den
+	}
 }


### PR DESCRIPTION
Hi!
I fixed division by zero, this happened, after running golocc from default directory(current), but this directory not contains *.go files.
`$ golocc`

```
--------------------------------------------------------------------------------
Lines of Code: 0 (0 CLOC, 0 NCLOC)
Imports:       0
Structs:       0
Interfaces:    0
panic: runtime error: integer divide by zero
[signal 0x8 code=0x1 addr=0x1 pc=0x804a22a]
...
```
